### PR TITLE
Upgrade Jetty (test dependency) to latest.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/pom.xml
+++ b/pom.xml
@@ -76,13 +76,13 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.2.7.v20150116</version>
+            <version>9.4.18.v20190429</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>9.2.7.v20150116</version>
+            <version>9.4.18.v20190429</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -144,9 +144,9 @@
                     <inherited>true</inherited>
                     <configuration>
                         <encoding>US-ASCII</encoding>
-                        <compilerVersion>1.7</compilerVersion>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <compilerVersion>1.8</compilerVersion>
+                        <source>1.8</source>
+                        <target>1.8</target>
                         <debug>true</debug>
                         <showDeprecation>true</showDeprecation>
                         <showWarnings>true</showWarnings>

--- a/src/test/java/com/signicat/hystrix/servlet/AsyncWrapperServletTest.java
+++ b/src/test/java/com/signicat/hystrix/servlet/AsyncWrapperServletTest.java
@@ -173,7 +173,7 @@ public class AsyncWrapperServletTest {
                     EntityUtils.consume(httpResponse.getEntity());
                     assertThat(servlet.servletComplete.await(60, TimeUnit.SECONDS), is(true));
                     assertThat(servlet.servletTimeout.getCount(), equalTo(1L));
-                    assertThat(servlet.servletError.getCount(), equalTo(1L));
+                    assertThat(servlet.servletError.await(60, TimeUnit.SECONDS), is(true));
                     assertThat(servlet.hystrixError.getCount(), equalTo(1L));
                     assertThat(servlet.hystrixCompleted.getCount(), equalTo(1L));
                     assertThat(servlet.hystrixNext.getCount(), equalTo(1L));


### PR DESCRIPTION
This caused one of the junit tests to fail, and it seems that they were
built with wrong assumptions. Jetty v9.3.3.v20150827 fixed some bugs with
the onError handling, namely:
 https://bugs.eclipse.org/bugs/show_bug.cgi?id=474617 AsyncListener.onError not called for errors
 https://bugs.eclipse.org/bugs/show_bug.cgi?id=474618 AsyncListener.onComplete not called when error occurs
 https://bugs.eclipse.org/bugs/show_bug.cgi?id=474634 AsyncListener.onError() handling