### PR TITLE
fix max threads

### DIFF
--- a/src/main/java/com/signicat/hystrix/servlet/AsyncWrapperServlet.java
+++ b/src/main/java/com/signicat/hystrix/servlet/AsyncWrapperServlet.java
@@ -118,7 +118,7 @@ public class AsyncWrapperServlet extends HttpServlet {
         //double thread pool size for pool with magic name 'default'
         final int maxSize  = DEFAULT_COMMAND_GROUP_KEY.equals(key) ? (corePoolSize * 2) : corePoolSize;
         final int coreSize = Math.min(10, maxSize);
-        final int queueSize          = (int) (((double) corePoolSize) * 1.4d);
+        final int queueSize          = (int) (corePoolSize * 1.4d);
         final int queueRejectionSize = queueSize + maxSize;
 
         BaseServletCommand command =

--- a/src/main/java/com/signicat/hystrix/servlet/AsyncWrapperServlet.java
+++ b/src/main/java/com/signicat/hystrix/servlet/AsyncWrapperServlet.java
@@ -115,10 +115,10 @@ public class AsyncWrapperServlet extends HttpServlet {
                             (req.getPathInfo() == null ? "" : req.getPathInfo());
         log.info("Scheduling Hystrix command with key '" + key + "' for path: '" + path + "'.");
 
-        //double thread pool size for pool with magic name 'default'
-        final int maxSize  = DEFAULT_COMMAND_GROUP_KEY.equals(key) ? (corePoolSize * 2) : corePoolSize;
+        // double thread pool size for pool with magic name 'default'
+        final int maxSize = DEFAULT_COMMAND_GROUP_KEY.equals(key) ? corePoolSize*2 : corePoolSize;
         final int coreSize = Math.min(10, maxSize);
-        final int queueSize          = (int) (corePoolSize * 1.4d);
+        final int queueSize = (int) (corePoolSize*1.4d);
         final int queueRejectionSize = queueSize + maxSize;
 
         BaseServletCommand command =

--- a/src/main/java/com/signicat/hystrix/servlet/AsyncWrapperServlet.java
+++ b/src/main/java/com/signicat/hystrix/servlet/AsyncWrapperServlet.java
@@ -116,9 +116,10 @@ public class AsyncWrapperServlet extends HttpServlet {
         log.info("Scheduling Hystrix command with key '" + key + "' for path: '" + path + "'.");
 
         //double thread pool size for pool with magic name 'default'
-        final int coreSize = DEFAULT_COMMAND_GROUP_KEY.equals(key) ? (corePoolSize * 2) : corePoolSize;
+        final int maxSize  = DEFAULT_COMMAND_GROUP_KEY.equals(key) ? (corePoolSize * 2) : corePoolSize;
+        final int coreSize = Math.min(10, maxSize);
         final int queueSize          = (int) (((double) corePoolSize) * 1.4d);
-        final int queueRejectionSize = (int) (((double) corePoolSize) * 1.2d);
+        final int queueRejectionSize = queueSize + maxSize;
 
         BaseServletCommand command =
                 new BaseServletCommand(
@@ -137,7 +138,9 @@ public class AsyncWrapperServlet extends HttpServlet {
                                                 .withRequestLogEnabled(false))
                                 .andThreadPoolPropertiesDefaults(
                                         HystrixThreadPoolProperties.Setter()
+                                                .withAllowMaximumSizeToDivergeFromCoreSize(true)
                                                 .withCoreSize(coreSize)
+                                                .withMaximumSize(maxSize)
                                                 .withMaxQueueSize(queueSize)
                                                 .withKeepAliveTimeMinutes(1)
                                                 .withQueueSizeRejectionThreshold(queueRejectionSize)),


### PR DESCRIPTION
this never worked as intended as hystrix was set to reject requests when the work queue was full (it is when the queue is full the thread pool will start spinning up threads past `coreSize`, up to maxSize)